### PR TITLE
fix(security): command injection, race condition, http timeouts, api key exposure

### DIFF
--- a/src/main/java/org/craftarix/monitoring/VoteMenu.java
+++ b/src/main/java/org/craftarix/monitoring/VoteMenu.java
@@ -11,9 +11,19 @@ import org.craftarix.monitoring.util.BukkitTasks;
 import org.craftarix.monitoring.util.JsonUtil;
 import org.craftarix.monitoring.util.ItemUtil;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class VoteMenu extends PaginatedMenu {
 
     private static final Settings settings = MonitoringPlugin.INSTANCE.getSettings();
+
+    // FIX: Race Condition - множество игроков, у которых голос уже обрабатывается
+    private static final Set<UUID> purchaseInProgress =
+            Collections.newSetFromMap(new ConcurrentHashMap<>());
+
     private final VoteService voteService;
     private int currentVotes;
 
@@ -21,7 +31,6 @@ public class VoteMenu extends PaginatedMenu {
         super(settings.getInventoryTitle(), 54);
         voteService = MonitoringPlugin.INSTANCE.getVoteService();
         setMarkupList(Lists.newArrayList(settings.getProductSlots()));
-
         setNextIcon(settings.getNextPage());
         setPrevIcon(settings.getPrevPage());
     }
@@ -32,16 +41,11 @@ public class VoteMenu extends PaginatedMenu {
             BukkitTasks.runTaskAsync(() -> {
                 serviceAsync.getVotesAsync(player.getName())
                         .whenComplete(((response, throwable) -> {
-                            if (response == null) {
-                                return;
-                            }
-                            if (response.statusCode() != 200) {
-                                return;
-                            }
+                            if (response == null) return;
+                            if (response.statusCode() != 200) return;
+
                             currentVotes = JsonUtil.unparseJson(response.body(), GetVotesModel.class).getBalance();
-                            BukkitTasks.runTask(() -> {
-                                super.openInventory(player);
-                            });
+                            BukkitTasks.runTask(() -> super.openInventory(player));
                         }));
             });
         } else {
@@ -62,21 +66,33 @@ public class VoteMenu extends PaginatedMenu {
         settings.getProducts().forEach(product -> {
             var newIcon = ItemUtil.replace(product.getIcon(), "{votes}", String.valueOf(currentVotes));
             addToMarkup(newIcon, (event) -> {
+                UUID playerId = player.getUniqueId();
+
                 if (currentVotes < product.getPrice()) {
                     replaceItem(event.getSlot(), settings.getNotEnoughVotesIcon(), 40);
-                    settings.getNotEnoughVotesMessages().forEach(message -> {
-                        player.sendMessage(message.replace("{player}", player.getName())
-                                .replace("{votes}", String.valueOf(currentVotes)));
-                    });
-                } else {
+                    settings.getNotEnoughVotesMessages().forEach(message ->
+                            player.sendMessage(message
+                                    .replace("{player}", player.getName())
+                                    .replace("{votes}", String.valueOf(currentVotes))));
+                    return;
+                }
+
+                // Блокируем повторный клик пока обработка не завершена
+                if (!purchaseInProgress.add(playerId)) {
+                    return;
+                }
+
+                try {
                     product.executeCommands(player);
                     voteService.takeVote(player.getName(), product.getPrice());
                     currentVotes -= product.getPrice();
                     updateInventory(player);
                     replaceItem(event.getSlot(), settings.getSuccessBuyIcon(), 40);
+                } finally {
+                    // Снимаем блокировку в любом случае даже при исключении
+                    purchaseInProgress.remove(playerId);
                 }
             });
         });
-
     }
 }

--- a/src/main/java/org/craftarix/monitoring/api/McEcoServiceAsync.java
+++ b/src/main/java/org/craftarix/monitoring/api/McEcoServiceAsync.java
@@ -1,6 +1,7 @@
 package org.craftarix.monitoring.api;
 
 import lombok.NonNull;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.craftarix.monitoring.api.model.CurrentServerModel;
 import org.craftarix.monitoring.api.model.TakeVoteModel;
@@ -11,16 +12,34 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
 public class McEcoServiceAsync implements VoteService {
-    private static final HttpClient httpClient = HttpClient.newHttpClient();
-    private final static String user_url = "https://minecraft.eco"; // ?????
-    private final static String api_url = "https://api.minecraft.eco";
+
+    // FIX: HTTP без таймаута - добавлены connectTimeout и requestTimeout
+    private static final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final String API_URL = "https://api.minecraft.eco";
 
     private final String apiKey;
 
     public McEcoServiceAsync(String apiKey) {
+        // FIX: Открытый API-ключ - проверяем наличие и предупреждаем, но не логируем значение
+        if (apiKey == null || apiKey.isBlank()) {
+            Bukkit.getLogger().log(Level.SEVERE,
+                    "[MinecraftEcoVote] API-ключ не задан! Укажите apiKey в config.yml");
+        } else {
+            // Показываем только первые 4 символа, остальное маскируем
+            String masked = apiKey.substring(0, Math.min(4, apiKey.length()))
+                    + "*".repeat(Math.max(0, apiKey.length() - 4));
+            Bukkit.getLogger().log(Level.INFO,
+                    "[MinecraftEcoVote] API-ключ загружен: " + masked);
+        }
         this.apiKey = apiKey;
     }
 
@@ -52,17 +71,28 @@ public class McEcoServiceAsync implements VoteService {
         return null;
     }
 
-    private CompletableFuture<HttpResponse<String>> getResponse(@NonNull String requestAddress, @NonNull String method, String writableJson) {
+    private CompletableFuture<HttpResponse<String>> getResponse(
+            @NonNull String requestAddress,
+            @NonNull String method,
+            String writableJson) {
         try {
-            var body = writableJson == null ? HttpRequest.BodyPublishers.noBody() : HttpRequest.BodyPublishers.ofString(writableJson);
-            var httpRequest = HttpRequest.newBuilder(new URI(api_url + requestAddress))
+            var body = writableJson == null
+                    ? HttpRequest.BodyPublishers.noBody()
+                    : HttpRequest.BodyPublishers.ofString(writableJson);
+
+            var httpRequest = HttpRequest.newBuilder(new URI(API_URL + requestAddress))
                     .header("Content-Type", "application/json")
                     .header("Authorization", "PT " + apiKey)
+                    // FIX: HTTP без таймаута - таймаут на весь запрос
+                    .timeout(REQUEST_TIMEOUT)
                     .method(method, body)
                     .build();
+
             return httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofString());
         } catch (Exception e) {
-            e.printStackTrace();
+            // FIX: Открытый API-ключ - не выводим apiKey в стектрейсе
+            Bukkit.getLogger().log(Level.SEVERE,
+                    "[MinecraftEcoVote] Ошибка HTTP-запроса к " + requestAddress, e);
             return null;
         }
     }

--- a/src/main/java/org/craftarix/monitoring/command/VoteCommand.java
+++ b/src/main/java/org/craftarix/monitoring/command/VoteCommand.java
@@ -8,6 +8,7 @@ import org.craftarix.monitoring.MonitoringPlugin;
 import org.craftarix.monitoring.VoteMenu;
 
 public class VoteCommand implements CommandExecutor {
+
     @Override
     public boolean onCommand(CommandSender commandSender, Command command, String s, String[] strings) {
         if (strings.length >= 1) {
@@ -19,7 +20,14 @@ public class VoteCommand implements CommandExecutor {
                 return true;
             }
         }
-        new VoteMenu().openInventory((Player) commandSender);
+
+        // FIX: NPE/ClassCast - раньше консоль/командный блок вызывали падение
+        if (!(commandSender instanceof Player player)) {
+            commandSender.sendMessage("[MinecraftEcoVote] Эта команда только для игроков.");
+            return true;
+        }
+
+        new VoteMenu().openInventory(player);
         return true;
     }
 }

--- a/src/main/java/org/craftarix/monitoring/config/Product.java
+++ b/src/main/java/org/craftarix/monitoring/config/Product.java
@@ -7,19 +7,34 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.List;
+import java.util.logging.Level;
+import java.util.regex.Pattern;
 
 @AllArgsConstructor
 @Getter
 public class Product {
+
+    // FIX: Command Injection - whitelist разрешённых символов в имени игрока
+    private static final Pattern SAFE_PLAYER_NAME = Pattern.compile("^[a-zA-Z0-9_]{1,16}$");
 
     private final ItemStack icon;
     private final Integer price;
     private final List<String> onBuyCommands;
 
     public void executeCommands(Player player) {
+        String playerName = player.getName();
+
+        // Отклоняем выполнение если имя содержит посторонние символы
+        if (!SAFE_PLAYER_NAME.matcher(playerName).matches()) {
+            Bukkit.getLogger().log(Level.WARNING,
+                    "[MinecraftEcoVote] Blocked command execution: unsafe player name '" + playerName + "'");
+            return;
+        }
+
         onBuyCommands.forEach(command -> {
             if (command.contains("{player}")) {
-                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command.replace("{player}", player.getName()));
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(),
+                        command.replace("{player}", playerName));
             } else {
                 player.chat(command);
             }


### PR DESCRIPTION
- Product: validate player name against [a-zA-Z0-9_] before command dispatch
- VoteMenu: add per-player UUID lock to prevent double-purchase on rapid clicks
- VoteCommand: guard against ClassCastException when called from console/command block
- McEcoServiceAsync: add connect (5s) and request (10s) timeouts to HttpClient
- McEcoServiceAsync: mask api key in logs, exclude it from exception stacktraces